### PR TITLE
docs(README): fix wrong type annotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ class User:
     id: int
     name: str
 
-def error_handler(d: Mapping[int, Union[int, str]], i: int, e: Exception) -> None:
+def error_handler(d: Mapping[str, Union[int, str]], i: int, e: Exception) -> None:
     print(f"{i}th element `{d}` is invalid due to the following error: {e}")
 
 raw_data = [{"id": 0, "name": "Alice"}, {"name": "lack of id"}, {"id": 1, "name": "Bob"}]


### PR DESCRIPTION
# Description

Fix typo on an example in the README.md

Fixes #33 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
